### PR TITLE
PDO ODBC extension does not support function 'lastInsertId'.

### DIFF
--- a/Adapter/Driver/Pdo/Connection.php
+++ b/Adapter/Driver/Pdo/Connection.php
@@ -398,7 +398,7 @@ class Connection extends AbstractConnection
      */
     public function getLastGeneratedValue($name = null)
     {
-        if ($name === null && $this->driverName == 'pgsql') {
+        if ($name === null && (('pgsql' == $this->driverName) || ('odbc' == $this->driverName))) {
             return;
         }
 


### PR DESCRIPTION
The ZF2 component code generate the following exception when running on latest Zend Server:
Uncaught exception 'PDOException' with message 'SQLSTATE[IM001]: Driver does not support this function: driver does not support lastInsertId() 

It seems the implementation in latest version of PDO_ODBC 1.0.1 from 2006 lacks a proper implementation of the feature even if the method exists.